### PR TITLE
Review/products

### DIFF
--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -98,10 +98,12 @@
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
           ut labore et
         </p>
-        <button class="hero-milk__btn circle-btn">
-          <svg width="5" height="18" class="hero-milk__btn-icon circle-btn__arrow">
-            <use href="images/icons.svg#icon-arrow-right"></use>
-          </svg>
+        <button class="hero-milk__btn circle-btn" type="button">
+          <a href="#about" class="hero-milk__link">
+            <svg width="5" height="18" class="hero-milk__btn-icon circle-btn__arrow">
+              <use href="images/icons.svg#icon-arrow-right"></use>
+            </svg>
+          </a>
         </button>
       </div>
     </div>

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -21,12 +21,12 @@
 
     <div class="header-buttons">
       <button
-        class="menu-toggler js-open-menu"
+        class="menu-toggle js-open-menu"
         type="button"
         aria-expanded="false"
         aria-controls="mobile-menu"
       >
-        <svg class="menu-toggler__icon" width="20" height="20">
+        <svg class="menu-toggle__icon" width="20" height="20">
           <use href="images/icons.svg#icon-Burger"></use>
         </svg>
       </button>

--- a/src/partials/products.html
+++ b/src/partials/products.html
@@ -1,7 +1,8 @@
 <!-- PRODUCTS -->
 <section class="products" id="products">
-  <a name="products" class="products__label">100% natural</a>
+  <p class="products__label">100% natural</p>
   <h2 class="products__title">products</h2>
+  <!-- zmienić klasy BEM -->
   <ul class="products__list">
     <li class="products__item">
       <h3 class="products__name products__name--first">ice cream</h3>
@@ -11,7 +12,7 @@
       </p>
       <button
         type="button"
-        class="circle-btn circle-btn--products products__btn"
+        class="products__btn circle-btn circle-btn--products"
         data-modal-open--productsFirst
       >
         <svg width="12" height="36" class="circle-btn__arrow circle-btn__arrow--products">

--- a/src/partials/products.html
+++ b/src/partials/products.html
@@ -8,7 +8,7 @@
       <h3 class="products__name products__name--first">ice cream</h3>
       <p class="products__description">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et. dolore magna aliqua facilisis.
+        labore et.<span class="products__description--long">dolore magna aliqua facilisis.</span>
       </p>
       <button
         type="button"
@@ -24,7 +24,7 @@
       <h3 class="products__name products__name--second">ice coffee</h3>
       <p class="products__description">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et. dolore magna aliqua facilisis.
+        labore et.<span class="products__description--long">dolore magna aliqua facilisis.</span>
       </p>
       <button
         type="button"
@@ -40,7 +40,7 @@
       <h3 class="products__name products__name--third">milkshakes</h3>
       <p class="products__description">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et. dolore magna aliqua facilisis.
+        labore et.<span class="products__description--long">dolore magna aliqua facilisis.</span>
       </p>
       <button
         type="button"

--- a/src/sass/partials/_buttons.scss
+++ b/src/sass/partials/_buttons.scss
@@ -23,7 +23,6 @@
 
     &--products {
       display: block;
-      text-align: center;
       margin: 0 auto;
     }
   }
@@ -93,6 +92,12 @@
   }
 }
 
+.menu-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
 @media screen and (min-width: 768px) {
   .button {
     &--mid {
@@ -111,10 +116,4 @@
     padding: 0.85em 1.6em;
     font-size: 14px;
   }
-}
-
-.menu-toggle {
-  background: none;
-  border: none;
-  cursor: pointer;
 }

--- a/src/sass/partials/_header.scss
+++ b/src/sass/partials/_header.scss
@@ -14,10 +14,7 @@
       display: none;
     }
 
-    .menu-toggler {
-      border: none;
-      background-color: transparent;
-
+    .menu-toggle {
       &__icon {
         display: block;
         stroke: $brandColor;
@@ -116,7 +113,7 @@
         display: block;
       }
 
-      .menu-toggler {
+      .menu-toggle {
         margin-right: 30px;
       }
     }
@@ -231,7 +228,7 @@
       padding-right: 115px;
     }
 
-    .menu-toggler {
+    .menu-toggle {
       display: none;
     }
   }

--- a/src/sass/partials/_products.scss
+++ b/src/sass/partials/_products.scss
@@ -160,8 +160,9 @@
       padding-right: 11px;
       line-height: 176%;
       margin-bottom: 40px;
-      height: 124px;
-      overflow: hidden;
+      &--long {
+        display: none;
+      }
     }
     &__btn {
       margin-bottom: 40px;
@@ -223,8 +224,6 @@
       padding-left: 44px;
       padding-right: 44px;
       margin-bottom: 62px;
-      height: 106px;
-      overflow: hidden;
     }
     &__btn {
       margin-bottom: 50px;

--- a/src/sass/partials/_products.scss
+++ b/src/sass/partials/_products.scss
@@ -3,7 +3,6 @@
   padding: 121px 20px 98px 20px;
   margin: 0 auto;
   &__label {
-    display: block;
     font-family: $accentFont, sans-serif;
     font-weight: 400;
     font-size: 18px;
@@ -55,7 +54,6 @@
     margin-top: 161px;
     margin-bottom: 66px;
     position: relative;
-    width: 100%;
     text-align: center;
     &--first::before {
       content: '';
@@ -183,7 +181,7 @@
     }
   }
 }
-@media screen and (min-width: 1200px) {
+@media screen and (min-width: 1280px) {
   .products {
     padding: 127px 113px 119px 113px;
     &__label {


### PR DESCRIPTION
-  class="products__btn circle-btn circle-btn--products" - zmieniłam kolejność klas, zgodnie z konwencją, że najpierw powinna być klasa specyficzna dla danego bloku, a później klasa globalna
- @media screen and (min-width: 1280px) - zmieniłam wartość media z 1200 px, zgodnie z zadaniem technicznym
- zmiana na początku html tagu <a> na <p> (tag a bez href chyba nie ma większego sensu)
- Zmieniłam stylizację opisu produktów. W stylach dla tabletu i desktop, wysokość paragrafu była ustawiona na sztywno, a nadmiar tekstu był chowany przez overflow: hidden. Wydaje mi się, że bardziej poprawnie byłoby po prostu zablokować wyświetlanie nadmiarowego tekstu i pozostawić paragrafowi automatyczną wysokość. Zawinęłam nadmiarowy tekst w span i dla większych rozdzielczości ustawiłam display: none.