### PR TITLE
contacts section review

### DIFF
--- a/src/partials/contacts.html
+++ b/src/partials/contacts.html
@@ -1,17 +1,17 @@
 <section id="contact" class="contacts">
-  <section class="contacts">
+ 
     <div class="container">
-      <h2 class="contacts__caption">Contacts</h2>
+      <h2 class="contacts__heading">Contacts</h2>
       <ul class="contacts__list">
         <li class="contacts__item">
-          <h3 class="contacts__label">Cafe</h3>
-          <h4 class="contacts__header">Chicago</h4>
+          <p class="contacts__label">Cafe</p>
+          <h3 class="contacts__header">Chicago</h3>
           <p class="contacts__text">Fusce ut velit laoreet, tempus arcu molestie vulputate</p>
           <div class="contacts__line"></div>
           <div class="contacts__schedule">
-            <h4 class="contacts__title">Monday - Friday</h4>
+            <h3 class="contacts__title">Monday - Friday</h3>
             <p class="contacts__time">06:00 Am - 10:00 pm</p>
-            <h4 class="contacts__title">Saturday - Sunday</h4>
+            <h3 class="contacts__title">Saturday - Sunday</h3>
             <p class="contacts__time">08:00 Am - 16:00 pm</p>
           </div>
           <div class="contacts__line"></div>
@@ -21,14 +21,14 @@
           </address>
         </li>
         <li class="contacts__item">
-          <h3 class="contacts__label contacts__label--secondary">Foodtruck</h3>
-          <h4 class="contacts__header">Los Angeles</h4>
+          <p class="contacts__label contacts__label--secondary">Foodtruck</p>
+          <h3 class="contacts__header">Los Angeles</h3>
           <p class="contacts__text">Fusce ut velit laoreet, tempus arcu molestie vulputate</p>
           <div class="contacts__line"></div>
           <div class="contacts__schedule">
-            <h4 class="contacts__title">Monday - Friday</h4>
+            <h3 class="contacts__title">Monday - Friday</h3>
             <p class="contacts__time">06:00 Am 10:00 pm</p>
-            <h4 class="contacts__title">Saturday - Sunday</h4>
+            <h3 class="contacts__title">Saturday - Sunday</h3>
             <p class="contacts__time">08:00 Am - 16:00 pm</p>
           </div>
           <div class="contacts__line"></div>
@@ -38,14 +38,14 @@
           </address>
         </li>
         <li class="contacts__item">
-          <h3 class="contacts__label">Cafe</h3>
-          <h4 class="contacts__header">New York</h4>
+          <p class="contacts__label">Cafe</p>
+          <h3 class="contacts__header">New York</h3>
           <p class="contacts__text">Fusce ut velit laoreet, tempus arcu molestie vulputate</p>
           <div class="contacts__line"></div>
           <div class="contacts__schedule">
-            <h4 class="contacts__title">Monday - Friday</h4>
+            <h3 class="contacts__title">Monday - Friday</h3>
             <p class="contacts__time">06:00 Am 10:00 pm</p>
-            <h4 class="contacts__title">Saturday - Sunday</h4>
+            <h3 class="contacts__title">Saturday - Sunday</h3>
             <p class="contacts__time">08:00 Am - 16:00 pm</p>
           </div>
           <div class="contacts__line"></div>
@@ -67,6 +67,5 @@
           </svg>
         </button>
       </div>
-    </div>
-  </section>
+
 </section>

--- a/src/sass/partials/_contacts.scss
+++ b/src/sass/partials/_contacts.scss
@@ -3,7 +3,7 @@
   position: relative;
   margin-top: 86px;
 
-  &__caption {
+  &__heading {
     display: none;
   }
 
@@ -37,13 +37,12 @@
     border-radius: 4px;
     background-color: $accentColor;
     padding: 1px 24px;
-    max-width: 80px;
+    display: inline-block;
     margin-bottom: 25px;
   }
 
   &__label--secondary {
     background-color: $secondaryAccentColor;
-    max-width: 130px;
   }
 
   &__header {
@@ -85,7 +84,7 @@
     line-height: 1.9;
     text-transform: uppercase;
 
-    &:not(last-of-type) {
+    &:not(:last-of-type) {
       margin-bottom: 10px;
     }
   }
@@ -103,7 +102,6 @@
     font-weight: $regular;
     letter-spacing: 0.04em;
     text-decoration: none;
-    cursor: pointer;
     font-style: normal;
   }
 
@@ -177,13 +175,11 @@
       font-size: 16px;
       border-radius: 6px;
       padding: 5px 16px;
-      max-width: 73px;
       margin-bottom: 30px;
     }
 
     &__label--secondary {
       background-color: $secondaryAccentColor;
-      max-width: 138px;
     }
 
     &__header {
@@ -207,7 +203,7 @@
     &__time {
       font-size: 14px;
 
-      &:not(last-of-type) {
+      &:not(:last-of-type) {
         margin-bottom: 16px;
       }
     }
@@ -280,7 +276,7 @@
     &__time {
       font-size: 16px;
 
-      &:not(last-of-type) {
+      &:not(:last-of-type) {
         margin-bottom: 15px;
       }
     }


### PR DESCRIPTION
    • Usunęłam dublujące się tagi section
    • zmieniłam klasę contacts__caption na contacts__heading – jedynie kwestia ujednolicenia z innymi sekcjami
    • w contacts__label zmieniłam sztywne ustawienie maksymalnej szerokości na właściwość display: inline-block. Dzięki temu nie będzie problemu przy ewentualnej zmianie treści headingu. A paddingi były świetnie ustawione, więc szerokość pozostała taka sama.
    • poza tym, co do label, treść wymagań technicznych: „Napisy Cafe i Food Truck NIE SĄ nagłówkami. To są kategorie oddziałów. „ → zmieniłam na <p>, w związku z tym, niższy nagłówek zmieniłam na h3
    • usunęłam właściwość white-space: wrap z __text → jest to właściwość domyślna
    • w selektorze &:not(last-of-type) brakowało dwukropka przed last – kod nie działał
    • usunęłam właściwość cursor:pointer z __link → jest to właściwość domyślna
